### PR TITLE
Add registries to the user depot

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,13 +43,14 @@ const cloneRegistry = async () => {
   const meta = toml.parse(fs.readFileSync(path.join(tmpdir, "Registry.toml")));
   const name = meta.name || registry.split("/")[1];
   const depot = process.env.JULIA_DEPOT_PATH || path.join(home, ".julia");
-  const dest = path.join(depot, "registries", name);
+  const user_depot = depot.split(path.delimiter)[0];
+  const dest = path.join(user_depot, "registries", name);
   if (fs.existsSync(dest)) {
     tmpdirCleanup();
   } else {
     fs.moveSync(tmpdir, dest);
   }
-  const general = path.join(depot, "registries", "General");
+  const general = path.join(user_depot, "registries", "General");
   if (!fs.existsSync(general)) {
     await exec.exec(`git clone git@github.com:JuliaRegistries/General.git ${general}`);
   }


### PR DESCRIPTION
Supports `JULIA_DEPOT_PATH`s which include multiple depots.