### PR TITLE
Avoid cloning cached registries

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,9 +40,9 @@ function getRegistryName(registry_dir) {
   return meta.name || registry.split("/").pop();
 }
 
-async function cloneRegistry(url, name) {
-  const registry_name = name || url.match(/([^\/]+)\.git$/)[1]
-  const registry_dir = path.join(DEPOT_PATH[0], "registries", registry_name);
+async function cloneRegistry(url) {
+  const repo_name = url.match(/([^\/]+)\.git$/)[1]
+  const registry_dir = path.join(DEPOT_PATH[0], "registries", repo_name);
   if (!fs.existsSync(registry_dir)) {
     await exec.exec(`git clone --no-progress ${url} ${registry_dir}`);
   }
@@ -69,7 +69,7 @@ async function main() {
   await updateKnownHosts();
   await cloneRegistry(`git@github.com:${registry}.git`);
   if (registry != "JuliaRegistries/General") {
-    await cloneRegistry("git@github.com:JuliaRegistries/General.git", "General");
+    await cloneRegistry("git@github.com:JuliaRegistries/General.git");
   }
   await configureGit();
 }

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const os = require("os");
 const path = require("path");
 
 const tmp = require("tmp");
-const toml = require('toml');
+const toml = require("toml");
 
 const core = require("@actions/core");
 const exec = require("@actions/exec");

--- a/main.js
+++ b/main.js
@@ -69,7 +69,9 @@ async function main() {
   await addKey(key);
   await updateKnownHosts();
   await cloneRegistry(`git@github.com:${registry}.git`, registry_name);
-  await cloneRegistry("git@github.com:JuliaRegistries/General.git", "General");
+  if (registry != "JuliaRegistries/General") {
+    await cloneRegistry("git@github.com:JuliaRegistries/General.git", "General");
+  }
   await configureGit();
 }
 

--- a/main.js
+++ b/main.js
@@ -44,7 +44,7 @@ async function cloneRegistry(url, name) {
   const registry_name = name || url.match(/([^\/]+)\.git$/)[1]
   const registry_dir = path.join(DEPOT_PATH[0], "registries", registry_name);
   if (!fs.existsSync(registry_dir)) {
-    await exec.exec(`git clone ${url} ${registry_dir}`);
+    await exec.exec(`git clone --no-progress ${url} ${registry_dir}`);
   }
 
   // When the registry name differs from the repo name we'll create a symlink for backwards

--- a/main.js
+++ b/main.js
@@ -50,10 +50,15 @@ async function cloneRegistry(url) {
   // When the registry name differs from the repo name we'll create a symlink for backwards
   // compatibility. When running `Pkg.Registry.update()` Julia will only update one of
   // these registries which avoids unnecessary overhead.
-  const alt_registry_dir = path.join(DEPOT_PATH[0], "registries", getRegistryName(registry_dir));
+  console.log("Get registry name")
+  const registry_name = getRegistryName(registry_dir)
+  console.log(`registry name = {registry_name}`)
+
+  const alt_registry_dir = path.join(DEPOT_PATH[0], "registries", registry_name);
   if (registry_dir != alt_registry_dir && !fs.existsSync(alt_registry_dir)) {
     fs.symlink(registry_dir, alt_registry_dir, "dir")
   }
+  console.log("symlink complete")
 };
 
 async function configureGit() {

--- a/main.js
+++ b/main.js
@@ -63,12 +63,11 @@ async function configureGit() {
 async function main() {
   const key = core.getInput("key", { required: true });
   const registry = core.getInput("registry", { required: true });
-  const registry_name = core.getInput("registry-name");
 
   await startAgent();
   await addKey(key);
   await updateKnownHosts();
-  await cloneRegistry(`git@github.com:${registry}.git`, registry_name);
+  await cloneRegistry(`git@github.com:${registry}.git`);
   if (registry != "JuliaRegistries/General") {
     await cloneRegistry("git@github.com:JuliaRegistries/General.git", "General");
   }

--- a/post.js
+++ b/post.js
@@ -1,11 +1,11 @@
 const core = require("@actions/core");
 const exec = require("@actions/exec");
 
-const undoGitConfig = async () => {
+async function undoGitConfig() {
   await exec.exec("git config --global --unset url.git@github.com:.insteadOf");
-};
+}
 
-const stopAgent = async () => {
+async function stopAgent() {
   const { stdout } = await exec.getExecOutput("ssh-agent -k");
   stdout.split("\n").forEach(line => {
     const match = /unset (.*);/.exec(line);
@@ -13,12 +13,12 @@ const stopAgent = async () => {
       core.exportVariable(match[1], "");
     }
   });
-};
+}
 
-const post = async () => {
+async function post() {
   await undoGitConfig();
   await stopAgent();
-};
+}
 
 if (!module.parent) {
   post().catch(e => {


### PR DESCRIPTION
Depends on:
- #22

Fixes:
- https://github.com/julia-actions/add-julia-registry/issues/19 (when using `julia-actions/cache` before this action with `cache-registries: true`. Enabled by default in `julia-actions/cache@v1.5.0`)

Moves away from cloning to a temporary directory in order to interact better with `julia-actions/cache` when registry cloning is enabled. The key component here is to use a consistent name of the registry such that we know the repo has already been downloaded and we can skip an additional clone. In order to do this I've opted to clone the registry using the repo name into the depot registry directory. As some registries can have different registry names from repo names I've added a symlink into the depot registry as well such that both names co-exist. 

Luckily, Julia is smart enough to avoid updating both registries. For example:
```sh
❯ mkdir -p /tmp/julia-depot/registries

❯ cd /tmp/julia-depot/registries

❯ export JULIA_DEPOT_PATH=/tmp/julia-depot

❯ git clone https://github.com/JuliaRegistries/General
Cloning into 'General'...
remote: Enumerating objects: 792384, done.
remote: Counting objects: 100% (11484/11484), done.
remote: Compressing objects: 100% (769/769), done.
remote: Total 792384 (delta 10868), reused 11214 (delta 10711), pack-reused 780900
Receiving objects: 100% (792384/792384), 230.00 MiB | 35.60 MiB/s, done.
Resolving deltas: 100% (432024/432024), done.
Updating files: 100% (42228/42228), done.

❯ ln -s General GeneralSymlink

❯ julia -e 'using Pkg; Pkg.Registry.update()'
    Updating registry at `/tmp/julia-depot/registries/General`
    Updating git-repo `https://github.com/JuliaRegistries/General`

❯ rm GeneralSymlink

❯ ln -s General 1-GeneralSymlink

❯ julia -e 'using Pkg; Pkg.Registry.update()'
    Updating registry at `/tmp/julia-depot/registries/1-GeneralSymlink`
    Updating git-repo `https://github.com/JuliaRegistries/General`

❯ julia-1.6 -e 'using Pkg; Pkg.Registry.update()'
    Updating registry at `/tmp/julia-depot/registries/1-GeneralSymlink`
    Updating git-repo `https://github.com/JuliaRegistries/General`
```