### PR TITLE
Fix error with `home`

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,7 +31,7 @@ async function addKey(key) {
 
 async function updateKnownHosts() {
   // Ensure that `known_hosts` always exists
-  const known_hosts_path = path.join(home, ".ssh", "known_hosts");
+  const known_hosts_path = path.join(HOME, ".ssh", "known_hosts");
   fs.ensureFileSync(known_hosts_path);
   
   // If we don't already have a mapping for `github.com`, get it automatically


### PR DESCRIPTION
Fixes this:
```
Run julia-actions/add-julia-registry@v1
/usr/bin/ssh-agent
SSH_AUTH_SOCK=/tmp/ssh-XXXXXXgtp5FP/agent.1822; export SSH_AUTH_SOCK;
SSH_AGENT_PID=1823; export SSH_AGENT_PID;
echo Agent pid 1823;
/usr/bin/ssh-add /tmp/tmp-1810-eJ8SVz0lN6eD
Identity added: /tmp/tmp-1810-eJ8SVz0lN6eD (/tmp/tmp-1810-eJ8SVz0lN6eD)
ReferenceError: home is not defined
    at updateKnownHosts (/home/runner/work/_actions/julia-actions/add-julia-registry/v1/main.js:34:38)
    at main (/home/runner/work/_actions/julia-actions/add-julia-registry/v1/main.js:84:9)
```