### PR TITLE
Update existing registries

### DIFF
--- a/main.js
+++ b/main.js
@@ -53,6 +53,8 @@ async function cloneRegistry(url, name) {
   const registry_dir = path.join(DEPOT_PATH[0], "registries", name || repo_name);
   if (!fs.existsSync(registry_dir)) {
     await exec.exec(`git clone --no-progress ${url} ${registry_dir}`);
+  } else {
+    await exec.exec(`git -C ${registry_dir} pull`);
   }
 
   // We have observed that toml parsing can be quite slow. We use the passed in name


### PR DESCRIPTION
Works around this issue with cached registries not being updated: https://github.com/julia-actions/cache/issues/110. In the future when this is potentially solved in Pkg.jl I think we can still leave in this logic as this action is all about adding registries so having this update step seems quite reasonable.