### PR TITLE
Use `julia-actions/cache@v2` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: 1
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/add-julia-registry@v2
         with:
           key: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
Use the `julia-actions/cache` version which supports Node 20 in the README.