### PR TITLE
Add HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
         with:
           version: "1"
       - uses: julia-actions/cache@v2
-      - uses: julia-actions/add-julia-registry@v3
+      - uses: julia-actions/add-julia-registry@v2
         with:
           registry: MyOrg/MyRegistry
           ssh-key: ${{ secrets.SSH_KEY }}
@@ -44,7 +44,7 @@ jobs:
         with:
           version: "1"
       - uses: julia-actions/cache@v2
-      - uses: julia-actions/add-julia-registry@v3
+      - uses: julia-actions/add-julia-registry@v2
         with:
           registry: MyOrg/MyRegistry
           protocol: https

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # Add Julia Registry
 
-If your package depends on private packages registered in a private registry, you need to handle authentication to that registry and the package repositories in a fully automated way, since you can't manually enter credentials in a CI environment.
-This action will deal with all of that for you, all you need is an SSH private key.
+Handles Git authentication to private Julia packages and registries such that they can be used within a CI environment. After running this action any GitHub HTTPS request made by Pkg will be automatically authenticated.
 
-```yml
+Currently, this action only support private packages hosted within GitHub.
+
+Access to private packages requires you to create a [SSH private key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) or a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) (with the proper repository access) in GitHub.
+
+## SSH Access
+
+```yaml
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -11,20 +16,43 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: 1
+          version: "1"
       - uses: julia-actions/cache@v2
-      - uses: julia-actions/add-julia-registry@v2
+      - uses: julia-actions/add-julia-registry@v3
         with:
-          key: ${{ secrets.SSH_KEY }}
           registry: MyOrg/MyRegistry
+          ssh-key: ${{ secrets.SSH_KEY }}
       - uses: julia-actions/julia-runtest@v1
 ```
 
-This action does the following:
+When using the SSH protocol this action performs the following steps:
 
-- Starts [ssh-agent](https://linux.die.net/man/1/ssh-agent)
-- Adds your private key to the agent
-- Configures Git to rewrite HTTPS URLs (`https://github.com/foo/bar`) to SSH URLs (`git@github.com:foo/bar`)
-- Downloads the registry you specify and [General](https://github.com/JuliaRegistries/General)
+- Starts [`ssh-agent`](https://linux.die.net/man/1/ssh-agent).
+- Adds the supplied private key to the SSH agent.
+- Configures Git to rewrite HTTPS URLs to SSH URLs (e.g. `https://github.com/foo/bar` to `git@github.com:foo/bar`).
+- Downloads the specified registry and the [General](https://github.com/JuliaRegistries/General) registry.
 
-Therefore, when Pkg tries to download packages from the HTTPS URLs in the registry, it will do so over SSH, using your private key as authentication.
+## HTTPS Access
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1"
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/add-julia-registry@v3
+        with:
+          registry: MyOrg/MyRegistry
+          protocol: https
+          github-token: ${{ secrets.GITHUB_TOKEN }}  # Using `${{ github.token }}` won't work for most use cases.
+      - uses: julia-actions/julia-runtest@v1
+```
+
+When using the HTTPS protocol this action performs the following steps:
+
+- Configures Git to rewrite unauthenticated HTTPS URLs to authenticated HTTPS URLs (e.g. `https://github.com/foo/bar` to `https://git:ghp_*****@github.com/foo/bar`)
+- Downloads the specified registry and the [General](https://github.com/JuliaRegistries/General) registry.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   ssh-key:
     description: SSH private key contents when cloning with SSH.
     required: false
+  key:
+    description: Deprecated input which was replaced by `ssh-key`.
+    required: false
   github-token:
     description: The GitHub token to use when cloning with HTTPS.
     default: ${{ github.token }}

--- a/action.yml
+++ b/action.yml
@@ -2,12 +2,18 @@ name: Add Julia Registry
 author: Chris de Graaf
 description: Clone a private Julia registry and configure Pkg access
 inputs:
-  key:
-    description: SSH private key contents
-    required: true
   registry:
     description: Registry to clone (owner/repo)
     required: true
+  protocol:
+    description: Protocol to use when cloning GitHub repositories. Either `ssh` or `https`.
+    default: ssh
+  ssh-key:
+    description: SSH private key contents when cloning with SSH.
+    required: false
+  github-token:
+    description: The GitHub token to use when cloning with HTTPS.
+    default: ${{ github.token }}
 runs:
   using: node20
   main: main.js

--- a/main.js
+++ b/main.js
@@ -84,7 +84,14 @@ async function configureGitInsteadOfHttps(github_token) {
 async function main() {
   const registry = core.getInput("registry", { required: true });
   const protocol = core.getInput("protocol", { required: true });
-  const ssh_key = core.getInput("ssh-key", { required: protocol == "ssh" }) || core.getInput("key", { required: protocol == "ssh" });
+
+  // While we support the deprecated `key` input we need to roll our own `required: protocol == "ssh"`
+  // const ssh_key = core.getInput("ssh-key", { required: protocol == "ssh" });
+  const ssh_key = core.getInput("ssh-key") || core.getInput("key");
+  if (protocol == "ssh" && !ssh_key) {
+    throw new Error("Input required and not supplied: ssh-key");
+  }
+
   const github_token = core.getInput("github-token", { required: protocol == "https" });
 
   if (protocol === "ssh") {

--- a/main.js
+++ b/main.js
@@ -84,7 +84,7 @@ async function configureGitInsteadOfHttps(github_token) {
 async function main() {
   const registry = core.getInput("registry", { required: true });
   const protocol = core.getInput("protocol", { required: true });
-  const ssh_key = core.getInput("ssh-key", { required: protocol == "ssh" });
+  const ssh_key = core.getInput("ssh-key", { required: protocol == "ssh" }) || core.getInput("key", { required: protocol == "ssh" });
   const github_token = core.getInput("github-token", { required: protocol == "https" });
 
   if (protocol === "ssh") {

--- a/main.js
+++ b/main.js
@@ -88,7 +88,7 @@ async function main() {
   // While we support the deprecated `key` input we need to roll our own `required: protocol == "ssh"`
   // const ssh_key = core.getInput("ssh-key", { required: protocol == "ssh" });
   const ssh_key = core.getInput("ssh-key") || core.getInput("key");
-  if (protocol == "ssh" && !ssh_key) {
+  if (protocol === "ssh" && !ssh_key) {
     throw new Error("Input required and not supplied: ssh-key");
   }
 

--- a/post.js
+++ b/post.js
@@ -1,11 +1,15 @@
 const core = require("@actions/core");
 const exec = require("@actions/exec");
 
-async function undoGitConfig() {
-  await exec.exec("git config --global --unset url.git@github.com:.insteadOf");
+async function unsetGitInsteadOfSsh() {
+  await exec.exec(`git config --global --unset url."git@github.com:".insteadOf`);
 }
 
-async function stopAgent() {
+async function unsetGitInsteadOfHttps(github_token) {
+  await exec.exec(`git config --global --unset url."https://git:${github_token}@github.com/".insteadOf`);
+}
+
+async function stopSshAgent() {
   const { stdout } = await exec.getExecOutput("ssh-agent -k");
   stdout.split("\n").forEach(line => {
     const match = /unset (.*);/.exec(line);
@@ -16,8 +20,15 @@ async function stopAgent() {
 }
 
 async function post() {
-  await undoGitConfig();
-  await stopAgent();
+  const protocol = core.getInput("protocol", { required: true });
+  const github_token = core.getInput("github-token", { required: protocol == "https" });
+
+  if (protocol === "ssh") {
+    await unsetGitInsteadOfSsh();
+    await stopSshAgent();
+  } else {
+    await unsetGitInsteadOfHttps(github_token);
+  }
 }
 
 if (!module.parent) {


### PR DESCRIPTION
Fixes #20. Supports authenticating via HTTPS when a PAT is provided. ~I've ended up making this change a breaking change since I renamed the input `key` to `ssh-key` for clarity.~